### PR TITLE
fix for superpixel

### DIFF
--- a/sunpy/image/rescale.py
+++ b/sunpy/image/rescale.py
@@ -151,8 +151,28 @@ def reshape_image_to_4d_superpixel(img, dimensions):
     """Re-shape the two dimension input image into a a four dimensional
     array whose 1st and third dimensions express the number of original
     pixels in the x and y directions form one superpixel. The reshaping
-    makes it very easy to perform operations on super-pixels.  Taken from
+    makes it very easy to perform operations on super-pixels.
+
+
+    Parameters
+    ----------
+    img : ndarray
+        A two-dimensional ndarray of the form (y, x)
+
+    dimensions : array-like
+        A two element array-like object containing integers that describe the
+        superpixel summation in the (y, x) directions
+
+    Returns
+    -------
+    A four dimensional ndarray that can be used to easily create
+    two-dimensional arrays of superpixels of the input image
+
+    References
+    ----------
+    Taken from
     http://mail.scipy.org/pipermail/numpy-discussion/2010-July/051760.html
+
     """
     # check that the dimensions divide into the image size exactly
 
@@ -161,9 +181,9 @@ def reshape_image_to_4d_superpixel(img, dimensions):
 
     # Reshape up to a higher dimensional array which is useful for higher
     # level operations
-    return img.reshape(img.shape[1] / dimensions[0],
+    return img.reshape(img.shape[0] / dimensions[0],
                        dimensions[0],
-                       img.shape[0] / dimensions[1],
+                       img.shape[1] / dimensions[1],
                        dimensions[1])
 
 class UnrecognizedInterpolationMethod(ValueError):

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -62,7 +62,7 @@ class GenericMap(NDData):
     cmap : matplotlib.colors.Colormap
         A color map used for plotting with matplotlib.
     mpl_color_normalizer : matplotlib.colors.Normalize
-        A matplotlib normalizer used to the image plot.
+        A matplotlib normalizer used to scale the image plot.
 
     Examples
     --------
@@ -983,15 +983,13 @@ scale:\t\t [{dx}, {dy}]
         #   coordinates in a Map are at pixel centers
 
         # Make a copy of the original data and perform reshaping
-        reshaped = reshape_image_to_4d_superpixel(self.data.copy().T,
-                                                  dimensions.value)
+        reshaped = reshape_image_to_4d_superpixel(self.data.copy(),
+                                                  [dimensions.value[1], dimensions.value[0]])
         if method == 'sum':
             new_data = reshaped.sum(axis=3).sum(axis=1)
         elif method == 'average':
             new_data = ((reshaped.sum(axis=3).sum(axis=1)) /
                     np.float32(dimensions[0] * dimensions[1]))
-        new_data = new_data.T
-
 
         # Update image scale and number of pixels
         new_map = deepcopy(self)
@@ -1010,8 +1008,8 @@ scale:\t\t [{dx}, {dy}]
             new_meta['CD2_2'] *= dimensions[1].value
         new_meta['crpix1'] = (new_nx + 1) / 2.
         new_meta['crpix2'] = (new_ny + 1) / 2.
-        new_meta['crval1'] = self.center['x']
-        new_meta['crval2'] = self.center['y']
+        new_meta['crval1'] = self.center['x'].value
+        new_meta['crval2'] = self.center['y'].value
 
         # Create new map instance
         new_map.data = new_data


### PR DESCRIPTION
The superpixel function was not working correctly.  It was getting the order of the dimensions mixed up.  Also, the returned map did not have the same units as the input map, causing a failure.