### PR TITLE
Fixes for the WCS PR

### DIFF
--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -881,7 +881,7 @@ scale:\t\t [{dx}, {dy}]
             elif range_a.unit.is_equivalent(u.pixel) and range_b.unit.is_equivalent(u.pixel):
                 units = 'pixels'
             else:
-                raise u.UnitsError("range_a and range_b but be"
+                raise u.UnitsError("range_a and range_b but be "
                                    "in units convertable to {} or {}".format(self.units['x'],
                                                                              u.pixel))
         else:
@@ -927,6 +927,7 @@ scale:\t\t [{dx}, {dy}]
         y_pixels = np.array(y_pixels)
         # Clip pixel values to max of array, prevents negative
         # indexing
+        x_pixels[np.less(x_pixels, 0)] = 0
         x_pixels[np.greater(x_pixels, self.data.shape[1])] = self.data.shape[1]
 
         y_pixels[np.less(y_pixels, 0)] = 0

--- a/sunpy/map/mapbase.py
+++ b/sunpy/map/mapbase.py
@@ -764,13 +764,17 @@ scale:\t\t [{dx}, {dy}]
         new_map.meta['crpix1'] += pad_x
         new_map.meta['crpix2'] += pad_y
 
-        array_center = (np.flipud(new_map.data.shape)-1)/2.0
+        # All of the following pixel calculations use a pixel origin of 0
 
+        pixel_array_center = (np.flipud(new_map.data.shape) - 1) / 2.0
+
+        # Convert the axis of rotation from data coordinates to pixel coordinates
+        pixel_rotation_center = u.Quantity(new_map.data_to_pixel(*rotation_center,
+                                                                 origin=0)).value
         if recenter:
-            # Convert the axis of rotation from data coordinates to pixel coordinates
-            pixel_center = u.Quantity(new_map.data_to_pixel(*rotation_center, origin=1)).value
+            pixel_center = pixel_rotation_center
         else:
-            pixel_center = array_center
+            pixel_center = pixel_array_center
 
         # Apply the rotation to the image data
         new_map.data = affine_transform(new_map.data.T,
@@ -780,25 +784,19 @@ scale:\t\t [{dx}, {dy}]
                                         recenter=recenter, missing=missing,
                                         use_scipy=use_scipy).T
 
-        # Calculate new reference pixel and coordinate at the center of the
-        # image.
         if recenter:
-            new_reference_pixel = array_center
+            new_reference_pixel = pixel_array_center
         else:
-            # Retrieve old pixel coordinates for the rotation center
-            old_reference_pixel = u.Quantity(new_map.data_to_pixel(*rotation_center,
-                                                                   origin=1)).value
-
             # Calculate new pixel coordinates for the rotation center
-            new_reference_pixel = array_center + np.dot(rmatrix,
-                                                        old_reference_pixel - pixel_center)
+            new_reference_pixel = pixel_center + np.dot(rmatrix,
+                                                        pixel_rotation_center - pixel_center)
             new_reference_pixel = np.array(new_reference_pixel).ravel()
 
-        # Define a new reference pixel in the rotated space
+        # Define the new reference_pixel
         new_map.meta['crval1'] = rotation_center[0].value
         new_map.meta['crval2'] = rotation_center[1].value
-        new_map.meta['crpix1'] = new_reference_pixel[0] + 1 # FITS counts pixels from 1
-        new_map.meta['crpix2'] = new_reference_pixel[1] + 1 # FITS counts pixels from 1
+        new_map.meta['crpix1'] = new_reference_pixel[0] + 1 # FITS pixel origin is 1
+        new_map.meta['crpix2'] = new_reference_pixel[1] + 1 # FITS pixel origin is 1
 
         # Unpad the array if necessary
         unpad_x = -np.min((diff[1], 0))

--- a/sunpy/map/tests/test_mapbase.py
+++ b/sunpy/map/tests/test_mapbase.py
@@ -240,13 +240,12 @@ def test_data_range(generic_map):
 
 
 def test_data_to_pixel(generic_map):
-    """Make sure conversion from data units to pixels is accurate"""
-    # Check conversion of reference pixel
-    # Note: FITS pixels starts from 1,1
-    assert_quantity_allclose(generic_map.data_to_pixel(generic_map.meta['crval1']*u.arcsec,
-                                                       generic_map.meta['crval2']*u.arcsec),
-                             u.Quantity([generic_map.meta['crpix1'] - 1,
-                                         generic_map.meta['crpix2'] - 1], unit=u.pixel))
+    """Make sure conversion from data units to pixels is internally consistent"""
+    # Note: FITS pixels start from 1,1
+    test_pixel = generic_map.data_to_pixel(*generic_map.reference_coordinate.values(),
+                                           origin=1)
+    assert_quantity_allclose(test_pixel,
+                             generic_map.reference_pixel.values())
 
 def test_submap(generic_map):
     """Check data and header information for a submap"""
@@ -379,13 +378,12 @@ def test_rotate(aia171_test_map):
     assert aia171_test_map_crop_rot.data.shape[0] < aia171_test_map_crop_rot.data.shape[1]
 
 
-def test_rotate_recenter(aia171_test_map):
-    array_center = (np.array(aia171_test_map.data.shape)-1)/2.0
+def test_rotate_recenter(generic_map):
+    rotated_map = generic_map.rotate(20*u.deg, recenter=True)
+    pixel_array_center = (np.flipud(rotated_map.data.shape) - 1) / 2.0
 
-    rotated_map = aia171_test_map.rotate(20*u.deg, recenter=True)
-
-    assert_quantity_allclose((array_center+1)*u.pix, # FITS indexes from 1
-                             u.Quantity(aia171_test_map.reference_pixel.values()))
+    assert_quantity_allclose((pixel_array_center + 1) * u.pix, # FITS indexes from 1
+                             u.Quantity(rotated_map.reference_pixel.values()))
 
 
 def test_rotate_crota_remove(aia171_test_map):


### PR DESCRIPTION
* Pixel calculations in rotate() actually assumed a pixel origin of 0, so reverted your changes and made assumption explicit
* Test for rotate's `recenter` keyword didn't actually test it
* Fixed missing protection in `submap()`
* Miscellaneous code cleanup