### PR TITLE
Astropy julian day fail

### DIFF
--- a/sunpy/physics/transforms/tests/test_solar_rotation.py
+++ b/sunpy/physics/transforms/tests/test_solar_rotation.py
@@ -42,15 +42,15 @@ def aia171_test_mapcube(aia171_test_submap):
 # Known displacements for these mapcube layers when the layer index is set to 0
 @pytest.fixture
 def known_displacements_layer_index0():
-    return {'x': np.asarray([-2.58637556e-12, -9.14263423e+00, -1.83031362e+01]),
-            'y': np.asarray([-3.38218342e-12, 1.95531618e-01, 3.80524463e-01])}
+    return {'x': np.asarray([1.222134e-12, -9.142634e+00, -1.830314e+01]),
+            'y': np.asarray([1.506351e-12, 1.955316e-01, 3.805245e-01])}
 
 
 # Known displacements for these mapcube layers when the layer index is set to 1
 @pytest.fixture
 def known_displacements_layer_index1():
-    return {'x': np.asarray([9.12386226e+00, -7.21911420e-12, -9.14259576e+00]),
-            'y': np.asarray([-2.06172237e-01, -9.26547727e-12, 1.95652214e-01])}
+    return {'x': np.asarray([9.123862e+00, 6.821210e-13, -9.142596e+00]),
+            'y': np.asarray([-2.061722e-01, 9.663381e-13, 1.956522e-01])}
 
 
 def test_calculate_solar_rotate_shift(aia171_test_mapcube, known_displacements_layer_index0, known_displacements_layer_index1):
@@ -90,6 +90,6 @@ def test_mapcube_solar_derotate(aia171_test_mapcube, aia171_test_submap):
     assert(isinstance(tmc, map.MapCube))
 
     # Test that the shape of data is correct when clipped
-    clipped_shape = (24, 20)
+    clipped_shape = (25, 19)
     for m in tmc:
         assert(m.data.shape == clipped_shape)

--- a/sunpy/time/julian.py
+++ b/sunpy/time/julian.py
@@ -10,12 +10,7 @@ def julian_day(t='now'):
     """
     Wrap a UTC -> JD conversion from astropy.
     """
-
-    time = parse_time(t)
-
-    t = Time(time)
-
-    return t.jd
+    return Time(parse_time(t)).jd
 
 # The number of days between Jan 1 1900 and the Julian reference date of
 # 12:00 noon Jan 1, 4713 BC


### PR DESCRIPTION
Due to microseconds now being taken into account when calculating the Julian time.  Updated solar rotation mapcube code.