### PR TITLE
Using fixtures on Helioviewer tests

### DIFF
--- a/sunpy/net/tests/test_helioviewer.py
+++ b/sunpy/net/tests/test_helioviewer.py
@@ -8,62 +8,55 @@ import sunpy
 import sunpy.map
 import pytest
 from sunpy.net.helioviewer import HelioviewerClient
+from sunpy.extern.six.moves import urllib
 
 from sunpy.tests.helpers import skip_glymur
 
+
+@pytest.fixture(scope="function")
+def client():
+    """
+    Fixture to create a client and skip tests if not available
+    """
+    try:
+        client = HelioviewerClient()
+        client.sources = client.get_data_sources()
+        return client
+    except (urllib.error.HTTPError), e:
+        print("There's a HTTP problem {} {}".format(e.code, e.args))
+        pytest.skip("HTTP error {}".format(e.code))
 
 @pytest.mark.online
 class TestHelioviewerClient:
     """Tests the Helioviewer.org API Client class"""
 
-    def setup_class(self):
-        self.client = HelioviewerClient()
-        if not self.client.is_online():
-            self.__SKIP_TESTS__ = True
-            print("Skipping Helioviewer.org tests (server inaccessible)")
-        else:
-            self.__SKIP_TESTS__ = False
-
-        self.sources = self.client.get_data_sources()
-
-    def teardown_class(self):
-        self.client = None
-
-    def test_get_datasources(self):
+    def test_get_datasources(self, client):
         """Makes sure datasource query returns a valid result and source id
         is casted to an integer"""
-        #  we skip these tests like this if the HV api is offline because
-        # we can not define __SKIP_TESTS__ in a scope that pytest.mark.skipif will find.
-        if self.__SKIP_TESTS__:
-            return
-        assert type(self.sources['SDO']['AIA']['AIA']['171']['sourceId']) is int
+        assert type(client.sources['SDO']['AIA']['AIA']['171']['sourceId']) is int
 
-    def test_get_closest_image(self):
+    def test_get_closest_image(self, client):
         """Tests getClosestImage API method"""
-        if self.__SKIP_TESTS__:
-            return
         # check basic query
-        im1 = self.client.get_closest_image('1994/01/01',
-                                              observatory='SOHO',
-                                              instrument='EIT',
-                                              detector='EIT',
-                                              measurement='195')
+        im1 = client.get_closest_image('1994/01/01',
+                                       observatory='SOHO',
+                                       instrument='EIT',
+                                       detector='EIT',
+                                       measurement='195')
         assert im1['width'] == im1['height'] == 1024
 
         # result should be same when using source id to query
-        source_id = self.sources['SOHO']['EIT']['EIT']['195']['sourceId']
+        source_id = client.sources['SOHO']['EIT']['EIT']['195']['sourceId']
 
-        im2 = self.client.get_closest_image('1994/01/01', sourceId=source_id)
+        im2 = client.get_closest_image('1994/01/01', sourceId=source_id)
 
         assert im1 == im2
 
     @skip_glymur
-    def test_download_jp2(self):
+    def test_download_jp2(self, client):
         """Tests getJP2Image API method"""
-        if self.__SKIP_TESTS__:
-            return
-        filepath = self.client.download_jp2('2020/01/01', observatory='SOHO',
-                                            instrument='MDI', detector='MDI',
-                                            measurement='continuum')
+        filepath = client.download_jp2('2020/01/01', observatory='SOHO',
+                                       instrument='MDI', detector='MDI',
+                                       measurement='continuum')
         map_ = sunpy.map.Map(filepath)
         assert isinstance(map_, sunpy.map.GenericMap)


### PR DESCRIPTION
This is to avoid to write lots of SKIP within the tests. If
the client is not started, then the tests won't run.
If the connection produces a HTTP error (because the url has
been modified or changed) then the skip will print such messages)